### PR TITLE
fix upper/lower case mistake in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "threads_a_gogo",
   "version": "0.1.5",
-  "main": "build/release/threads_a_gogo.node",
+  "main": "build/Release/threads_a_gogo.node",
   "description": "████ Simple and fast JavaScript threads for Node.js ████",
   "keywords": [
     "The",


### PR DESCRIPTION
node-waf compiles to build/Release on linux.
As linux filesystems are case sensitive, the module would not be found under build/release