### PR TITLE
process.nexttick was deprecated as of nodejs v0.10.0.

### DIFF
--- a/examples/quickIntro_blocking.js
+++ b/examples/quickIntro_blocking.js
@@ -4,10 +4,10 @@ function fibo (n) {
 
 (function fiboLoop () {
   process.stdout.write(fibo(35).toString());
-  process.nextTick(fiboLoop);
+  setImmediate(fiboLoop);
 })();
 
 (function spinForever () {
   process.stdout.write(".");
-  process.nextTick(spinForever);
+  setImmediate(spinForever);
 })();

--- a/examples/quickIntro_fiveThreads.js
+++ b/examples/quickIntro_fiveThreads.js
@@ -17,5 +17,5 @@ threads_a_gogo.create().eval(fibo).eval('fibo(35)', cb);
 
 (function spinForever () {
   process.stdout.write(".");
-  process.nextTick(spinForever);
+  setImmediate(spinForever);
 })();

--- a/examples/quickIntro_loop.js
+++ b/examples/quickIntro_loop.js
@@ -1,4 +1,4 @@
 (function spinForever () {
   process.stdout.write(".");
-  process.nextTick(spinForever);
+  setImmediate(spinForever);
 })();

--- a/examples/quickIntro_multiThread.js
+++ b/examples/quickIntro_multiThread.js
@@ -12,5 +12,5 @@ threadPool.all.eval('fibo(35)', function cb (err, data) {
 
 (function spinForever () {
   process.stdout.write(".");
-  process.nextTick(spinForever);
+  setImmediate(spinForever);
 })();

--- a/examples/quickIntro_multiThreadEvented.js
+++ b/examples/quickIntro_multiThreadEvented.js
@@ -26,5 +26,5 @@ threadPool.on('theFiboIs', function cb (data) {
 
 (function spinForever () {
   process.stdout.write(".");
-  process.nextTick(spinForever);
+  setImmediate(spinForever);
 })();

--- a/examples/quickIntro_oneThread.js
+++ b/examples/quickIntro_oneThread.js
@@ -13,5 +13,5 @@ thread.eval(fibo).eval('fibo(35)', cb);
 
 (function spinForever () {
   process.stdout.write(".");
-  process.nextTick(spinForever);
+  setImmediate(spinForever);
 })();

--- a/examples/quickIntro_oneThreadEvented.js
+++ b/examples/quickIntro_oneThreadEvented.js
@@ -25,5 +25,5 @@ thread.on('theFiboIs', function cb (data) {
 
 (function spinForever () {
   process.stdout.write(".");
-  process.nextTick(spinForever);
+  setImmediate(spinForever);
 })();


### PR DESCRIPTION
As of v0.10.0, node can detect that process.nextTick has been used recursively, and prints out a ton of warnings.  While this warning doesn't matter in this case, it does create a ton of extra output that hinders the ability to use the examples.