### PR TITLE
Fix main path in package.json to match node-gyp documentation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "threads_a_gogo",
   "version": "0.1.7",
-  "main": "build/release/threads_a_gogo.node",
+  "main": "build/Release/threads_a_gogo.node",
   "description": "████ Simple and fast JavaScript threads for Node.js ████",
   "keywords": [
     "The",


### PR DESCRIPTION
According to [node-gyp github](https://github.com/TooTallNate/node-gyp), the built
.node file is placed into ```build/Release```, not ```build/release```.  This
is a non-issue on case-insensitive file systems, but breaks this
lib on case-sensitive file systems.