### PR TITLE
Fixing case in .node binary path.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "threads_a_gogo",
   "version": "0.1.7",
-  "main": "build/release/threads_a_gogo.node",
+  "main": "build/Release/threads_a_gogo.node",
   "description": "████ Simple and fast JavaScript threads for Node.js ████",
   "keywords": [
     "The",


### PR DESCRIPTION
Fixes - https://github.com/xk/node-threads-a-gogo/issues/47

Otherwise the package from npm is unusable on case sensitive file systems.